### PR TITLE
Collecting game data in an sqlite db via plugin

### DIFF
--- a/apps/plugin/build.gradle
+++ b/apps/plugin/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     // Jackson
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
 
+    // sqlite
+    implementation "org.xerial:sqlite-jdbc:3.27.2.1"
+
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 

--- a/apps/plugin/src/main/java/com/tracker/DbClient.java
+++ b/apps/plugin/src/main/java/com/tracker/DbClient.java
@@ -1,0 +1,107 @@
+package com.tracker;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tracker.models.TelemetryData;
+
+// this is for sqlite
+public class DbClient {
+    private String dbString;
+    private Map<String, String> eventToTable = createMap();
+
+    private static Map<String, String> createMap() {
+        Map<String, String> eventToTable = new HashMap<String, String>();
+        eventToTable.put("stat-changed", "stat_changed");
+        eventToTable.put("hitsplat-applied", "hitsplat_applied");
+        eventToTable.put("actor-death", "actor_death");
+        eventToTable.put("grand-exchange-offer-changed", "grand_exchange_offer_changed");
+        eventToTable.put("game-tick", "game_tick");
+        eventToTable.put("loot-received", "loot_received");
+        return eventToTable;
+    }
+
+    private String getCreateTableQuery(String table) {
+        // each table has an id column and a TEXT column (will just be json)
+        String query = "CREATE TABLE IF NOT EXISTS " + table + " (\n" + "id integer PRIMARY KEY,\n"
+                + "data text NOT NULL\n" + ");";
+
+        return query;
+    }
+
+    public void initialiseDb() {
+
+        Connection con = connect();
+
+        // create a table for each event
+        for (String event : eventToTable.keySet()) {
+            String table = eventToTable.get(event);
+            String query = getCreateTableQuery(table);
+            try {
+                con.createStatement().execute(query);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+
+        try {
+            con.commit();
+            con.close();
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    public void StoreTelemetry(TelemetryData telemetryData) {
+        Connection con = connect();
+        String table = eventToTable.get(telemetryData.getEvent());
+
+        if (table == null) {
+            System.out.println("No table found for event: " + telemetryData.getEvent());
+            return;
+        }
+
+        String query = "INSERT INTO " + table + " (data) VALUES (?);";
+
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            String json = mapper.writeValueAsString(telemetryData);
+            PreparedStatement stmt = con.prepareStatement(query);
+            stmt.setString(1, json);
+            stmt.executeUpdate();
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+
+        try {
+            con.commit();
+            con.close();
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    public Connection connect() {
+
+        // TODO: actually put some thought into connection management
+        Connection conn = null;
+        try {
+            // check if the appropriate class is available
+            Class.forName("org.sqlite.JDBC");
+            conn = DriverManager.getConnection(dbString);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+        return conn;
+    }
+
+    // constructor
+    public DbClient(String dbString) {
+        // prefix with jdbc:sqlite:
+        this.dbString = "jdbc:sqlite:" + dbString;
+    }
+}

--- a/apps/plugin/src/main/java/com/tracker/DbClientFactory.java
+++ b/apps/plugin/src/main/java/com/tracker/DbClientFactory.java
@@ -1,0 +1,7 @@
+package com.tracker;
+
+public class DbClientFactory {
+    public DbClient createDbClient(String dbString) {
+        return new DbClient(dbString);
+    }
+}

--- a/apps/plugin/src/main/java/com/tracker/models/TelemetryData.java
+++ b/apps/plugin/src/main/java/com/tracker/models/TelemetryData.java
@@ -1,0 +1,16 @@
+package com.tracker.models;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+// telemetry data class definition
+@Getter
+@RequiredArgsConstructor
+public class TelemetryData {
+    private final long timestamp;
+    private final Object data;
+    private final String username;
+    private final String event;
+    private final long tickCount;
+    private final String sessionId;
+}

--- a/apps/plugin/src/test/java/com/tracker/TrackerPluginTest.java
+++ b/apps/plugin/src/test/java/com/tracker/TrackerPluginTest.java
@@ -1,15 +1,11 @@
 package com.tracker;
 
-import com.tracker.TrackerPlugin;
-
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 
 public class TrackerPluginTest {
-	public static void main(String[] args)
-			throws Exception {
-		ExternalPluginManager
-				.loadBuiltin(TrackerPlugin.class);
+	public static void main(String[] args) throws Exception {
+		ExternalPluginManager.loadBuiltin(TrackerPlugin.class);
 		RuneLite.main(args);
 	}
 }


### PR DESCRIPTION
Adding data collection using sqlite in the runelite plugin, currently just collecting all data pretty much exactly like how we were transmitting it to the original ingress, except this time it's getting put into a sqlite db. The db structure is very simple (basically treating it like a bootleg document db) where each "event" (i.e. game-tick, hitsplat-applied, etc) are a table with two columns: id, data. id is pk, and data is TEXT containing json data of the event.

example:

![image](https://github.com/Runelite-Wrapped/runelite-wrapped/assets/45305164/bb039331-9964-4d49-a229-f4bdac2c1716)


And i've uploaded the file here: [rlw.db.txt](https://github.com/Runelite-Wrapped/runelite-wrapped/files/13734458/rlw.db.txt), NOTE: i had to upload it with an accepted file extension... so I just added .txt to the end. To use it just rename it to `rlw.db`
